### PR TITLE
Feature/more setup options

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ wpc_init name-of-project
 
 You can edit `setup/internal.sh` to enable plugins and themes using wp-cli. (`setup/external.sh` also exists, if you need to run commands outside of the container).
 
+WXR files containing WordPress content can be placed in the project's `setup/content/` folder. This content will be imported on running the project for the first time.
+
 ## Usage
 
 Running the project for the first time:
@@ -32,7 +34,7 @@ Running the project after that:
 docker-compose up -d
 ```
 
-WordPress listens on port 80. Mailcatcher listens on port 1080.
+WordPress listens on port 80. Mailcatcher listens on port 1080. Beanstalkd Console listens on port 2080.
 
 MySQL is available by running `./bin/wp db cli`. It will also be listening on port 3306.
 

--- a/bin/wpc_init
+++ b/bin/wpc_init
@@ -137,12 +137,12 @@ set -e
 ##############
 # Config
 ##############
-title=your_site_title
+title="Your site title here"
 theme=your-theme-slug
 plugins="a-space-separated list-of plugins-to-activate"
 content=/usr/src/app/setup/content
 
-wp core install --skip-email --admin_user=admin --admin_password=admin --admin_email=admin@localhost.invalid --url=http://localhost --title=$title
+wp core install --skip-email --admin_user=admin --admin_password=admin --admin_email=admin@localhost.invalid --url=http://localhost --title="$title"
 
 for plugin in $plugins
 do

--- a/bin/wpc_init
+++ b/bin/wpc_init
@@ -36,6 +36,16 @@ services:
 
   beanstalk:
     image: schickling/beanstalkd
+    ports:
+      - "11300:11300"
+
+  beanstalkd_console:
+    image: agaveapi/beanstalkd-console
+    ports:
+      - "2080:80"
+    environment:
+      BEANSTALKD_HOST:beanstalk
+      BEANSTALKD_PORT:11300
 
   mysql:
     image: mysql
@@ -93,6 +103,8 @@ END
 
 creating bin/setup <<'END'
 #!/bin/sh
+#
+# Runs all site setup scripts
 set -e
 
 `dirname $0`/../setup/external.sh
@@ -121,7 +133,15 @@ set -e
 ## This code will be run during setup, INSIDE the container.
 ##
 
-wp core install --skip-email --admin_user=admin --admin_password=admin --admin_email=admin@localhost.invalid --url=http://localhost --title=Site
-# wp theme activate ...
-# wp plugin activate ...
+##############
+# Config
+##############
+title=your_site_title
+theme=your-theme-slug
+plugins="a-space-separated list-of plugins-to-activate"
+
+wp core install --skip-email --admin_user=admin --admin_password=admin --admin_email=admin@localhost.invalid --url=http://localhost --title=$title
+wp plugin activate $plugins
+wp theme activate $theme
+
 END

--- a/bin/wpc_init
+++ b/bin/wpc_init
@@ -19,6 +19,7 @@ creating() {
 
 makedir bin
 makedir setup
+makedir setup/content
 
 REPLACEMENT=`echo ${1} | perl -pe 'chomp;s/[^A-Za-z0-9_-]/_/g'`
 
@@ -44,8 +45,8 @@ services:
     ports:
       - "2080:80"
     environment:
-      BEANSTALKD_HOST:beanstalk
-      BEANSTALKD_PORT:11300
+      BEANSTALKD_HOST: beanstalk
+      BEANSTALKD_PORT: 11300
 
   mysql:
     image: mysql
@@ -139,9 +140,16 @@ set -e
 title=your_site_title
 theme=your-theme-slug
 plugins="a-space-separated list-of plugins-to-activate"
+content=/usr/src/app/setup/content/*
 
 wp core install --skip-email --admin_user=admin --admin_password=admin --admin_email=admin@localhost.invalid --url=http://localhost --title=$title
 wp plugin activate $plugins
 wp theme activate $theme
+
+for file in $content
+do
+  echo "Importing $file..."
+  wp import $file --authors=skip
+done
 
 END

--- a/bin/wpc_init
+++ b/bin/wpc_init
@@ -140,7 +140,7 @@ set -e
 title=your_site_title
 theme=your-theme-slug
 plugins="a-space-separated list-of plugins-to-activate"
-content=/usr/src/app/setup/content/*
+content=/usr/src/app/setup/content
 
 wp core install --skip-email --admin_user=admin --admin_password=admin --admin_email=admin@localhost.invalid --url=http://localhost --title=$title
 
@@ -161,10 +161,21 @@ else
   echo "\033[96mWarning:\033[0m Theme '"$theme"' could not be found. Have you installed it?"
 fi
 
-for file in $content
-do
-  echo "Importing $file..."
-  wp import $file --authors=skip
-done
+if [ "$(ls -A $content)" ]
+then
+  if wp plugin is-installed wordpress-importer
+  then
+    wp plugin activate wordpress-importer
+    for file in $content/*.xml
+    do
+      echo "Importing $file..."
+      wp import $file --authors=skip
+    done
+  else
+    echo "\033[96mWarning:\033[0m Cannot import content as wordpress-importer plugin is not installed"
+  fi
+else
+  echo "No content to be imported"
+fi
 
 END

--- a/bin/wpc_init
+++ b/bin/wpc_init
@@ -143,8 +143,23 @@ plugins="a-space-separated list-of plugins-to-activate"
 content=/usr/src/app/setup/content/*
 
 wp core install --skip-email --admin_user=admin --admin_password=admin --admin_email=admin@localhost.invalid --url=http://localhost --title=$title
-wp plugin activate $plugins
-wp theme activate $theme
+
+for plugin in $plugins
+do
+  if wp plugin is-installed $plugin
+  then
+    wp plugin activate $plugin
+  else
+    echo "\033[96mWarning:\033[0m Plugin '"$plugin"' could not be found. Have you installed it?"
+  fi
+done
+
+if wp theme is-installed $theme
+then
+  wp theme activate $theme
+else
+  echo "\033[96mWarning:\033[0m Theme '"$theme"' could not be found. Have you installed it?"
+fi
 
 for file in $content
 do

--- a/images/wordpress/Dockerfile
+++ b/images/wordpress/Dockerfile
@@ -10,7 +10,7 @@ RUN docker-php-ext-install mysqli && \
 
 # wp-cli
 RUN curl https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar > /usr/local/bin/wp-cli.phar &&\
-    /bin/echo -e '#!/bin/sh\nexec php /usr/local/bin/wp-cli.phar --allow-root ${@}' > /usr/local/bin/wp &&\
+    /bin/echo -e '#!/bin/sh\nexec php /usr/local/bin/wp-cli.phar --allow-root "${@}"' > /usr/local/bin/wp &&\
     chmod 755 /usr/local/bin/wp
 
 # WordPress


### PR DESCRIPTION
@tomdxw This adds a couple of things:

a) A Beanstalkd Console container (as suggested by @robbiepaul) that listens on port 2080.
b) The ability to import any WXR files that are placed in `/setup/content/` when running `bin/setup`.

I've also moved the user-definable bits of `internal.sh` to the top of the file for convenience. 