### PR TITLE
Feature/multi version

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,7 @@
+Copyright 2017 dxw
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -47,3 +47,27 @@ All the ports that docker will be listening on (80, 1080, 2080, 3066 & 11300) ne
 Things that might be running on port 80: apache (stop with `sudo apachectl stop`), any other local server (e.g. `whippet-server`, XAMPP)
 
 Things that might be running on port 3306: `mysql` (stop with `mysql.server stop`)
+
+## WordPress versions
+
+When the image is built, a copy of the latest version of WordPress is downloaded.
+
+When running the image, it will check for updates before starting Apache. It will also download older versions of WordPress via the `WORDPRESS_VERSION` environment variable.
+
+Example of using an older version (you should just need to add the two final lines):
+
+```
+  wordpress:
+    image: thedxw/wpc-wordpress
+    ports:
+      - "80:80"
+    links:
+      - mysql
+      - mailcatcher
+      - beanstalk
+    volumes:
+      - .:/usr/src/app
+      - ./wp-content:/var/www/html/wp-content
+    environment:
+      WORDPRESS_VERSION: 4.7
+```

--- a/images/wordpress/Dockerfile
+++ b/images/wordpress/Dockerfile
@@ -1,21 +1,24 @@
 FROM php:apache
 
-# APT
 RUN apt-get update && apt-get install -y --no-install-recommends libpng12-dev vim-tiny less mysql-client && rm -r /var/lib/apt/lists/*
 
-# PHP/Apache setup
 RUN docker-php-ext-install mysqli && \
     docker-php-ext-install gd && \
     a2enmod rewrite
 
-# wp-cli
 RUN curl --silent https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar > /usr/local/bin/wp-cli.phar
 
-# WordPress
+ENV WORDPRESS_VERSION=latest
+
+COPY wp /usr/local/bin/
+COPY wp-start /usr/local/bin/
+
 RUN wp core download --path=/var/www/html
 
 COPY php.ini /usr/local/etc/php/
 COPY wordpress.conf /etc/apache2/sites-enabled/
 COPY mu-plugins /usr/src/mu-plugins/
 COPY wp-config.php /var/www/html/wp-config.php
-COPY wp /usr/local/bin/
+
+ENTRYPOINT ["wp-start"]
+CMD ["apache2-foreground"]

--- a/images/wordpress/Dockerfile
+++ b/images/wordpress/Dockerfile
@@ -9,9 +9,7 @@ RUN docker-php-ext-install mysqli && \
     a2enmod rewrite
 
 # wp-cli
-RUN curl --silent https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar > /usr/local/bin/wp-cli.phar &&\
-    /bin/echo -e '#!/bin/sh\nexec php /usr/local/bin/wp-cli.phar --allow-root "${@}"' > /usr/local/bin/wp &&\
-    chmod 755 /usr/local/bin/wp
+RUN curl --silent https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar > /usr/local/bin/wp-cli.phar
 
 # WordPress
 RUN wp core download --path=/var/www/html
@@ -20,3 +18,4 @@ COPY php.ini /usr/local/etc/php/
 COPY wordpress.conf /etc/apache2/sites-enabled/
 COPY mu-plugins /usr/src/mu-plugins/
 COPY wp-config.php /var/www/html/wp-config.php
+COPY wp /usr/local/bin/

--- a/images/wordpress/Dockerfile
+++ b/images/wordpress/Dockerfile
@@ -14,10 +14,7 @@ RUN curl --silent https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/
     chmod 755 /usr/local/bin/wp
 
 # WordPress
-RUN curl --silent https://wordpress.org/latest.tar.gz > /usr/src/latest.tar.gz && \
-    tar -C /usr/src -xzf /usr/src/latest.tar.gz && \
-    rm -rf /var/www/html /usr/src/wordpress/wp-content && \
-    mv /usr/src/wordpress /var/www/html
+RUN wp core download --path=/var/www/html
 
 COPY php.ini /usr/local/etc/php/
 COPY wordpress.conf /etc/apache2/sites-enabled/

--- a/images/wordpress/wp
+++ b/images/wordpress/wp
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec php /usr/local/bin/wp-cli.phar --allow-root "${@}"

--- a/images/wordpress/wp-start
+++ b/images/wordpress/wp-start
@@ -1,0 +1,7 @@
+#!/bin/sh
+if test ${WORDPRESS_VERSION}X = latestX; then
+  wp core download --path=/var/www/html
+else
+  wp core download --path=/var/www/html --version=${WORDPRESS_VERSION} --force
+fi
+exec docker-php-entrypoint "${@}"


### PR DESCRIPTION
WordPress now gets updated automatically. And if you need to, you can install an older version with `WORDPRESS_VERSION` env var.

And a couple of extra bits: COPY wp instead of piping it out of echo into a file, add a licence file.