### PR TITLE
Add bcmath and exif extensions

### DIFF
--- a/images/wordpress/Dockerfile
+++ b/images/wordpress/Dockerfile
@@ -12,6 +12,8 @@ RUN docker-php-ext-install mysqli && \
     docker-php-ext-install pcntl &&\
     docker-php-ext-install sockets &&\
     docker-php-ext-install sysvsem &&\
+    docker-php-ext-install bcmath &&\
+    docker-php-ext-install exif &&\
     docker-php-ext-enable imagick && \
     a2enmod rewrite
 


### PR DESCRIPTION
These extensions are recommended by the Site Health Status page which
will be in WP 5.2.