### PR TITLE
Install mariadb-client instead of mysql-client

### DIFF
--- a/images/wordpress/Dockerfile
+++ b/images/wordpress/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7.3-apache
 
-RUN apt-get update && apt-get install -y --no-install-recommends libmagickwand-dev libjpeg-dev libpng-dev vim-tiny less mysql-client libgmp-dev libsodium-dev zlib1g-dev libzip-dev && rm -r /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends libmagickwand-dev libjpeg-dev libpng-dev vim-tiny less mariadb-client libgmp-dev libsodium-dev zlib1g-dev libzip-dev && rm -r /var/lib/apt/lists/*
 
 RUN pecl install imagick
 


### PR DESCRIPTION
MySQL was removed from Debian in Stretch, and mysql-client became a
transitional package. In Buster mysql-client has been removed entirely.