### PR TITLE
Create an image for the wpc tool itself

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM golang:1.13
+
+WORKDIR /go/src/github.com/wpc
+COPY . .
+
+RUN go get -d -v ./...
+RUN go install -v ./...
+
+WORKDIR /app
+ENTRYPOINT ["wpc"]

--- a/README.md
+++ b/README.md
@@ -2,12 +2,10 @@
 
 ## Installation
 
-`docker-compose` must be installed.
-
-With Go installed, and Go's `/bin` in your PATH variable:
+The easiest way to "install" wpc is to create an alias in your shell:
 
 ```
-go get github.com/dxw/wpc
+alias wpc='docker run -ti --rm -v `pwd`:/app thedxw/wpc'
 ```
 
 ## Setting up a project


### PR DESCRIPTION
This means if you have docker installed you can start using wpc
immediately without installing any additional dependencies.