### PR TITLE
Increase upload file size limit

### DIFF
--- a/images/wordpress/php.ini
+++ b/images/wordpress/php.ini
@@ -3,3 +3,5 @@ display_errors=Off
 log_errors=On
 variables_order=GPCSE
 short_open_tag=Off
+upload_max_filesize = 1G
+post_max_size = 1G


### PR DESCRIPTION
Currently, the image limits our upload size to 2MB. This frequently causes issues when testing, particularly if trying to import content.

Let's up that to 100MB - this only applied on local dev environments, so we should be fine.