### PR TITLE
Do not diff raw_templates.go

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+/raw_templates.go -diff


### PR DESCRIPTION
`raw_templates.go` is generated by `go generate` and its output can
change even when no changes have been made due to `range` operating
randomly on maps.