### PR TITLE
Send emails from valid address in WP v5.5

### DIFF
--- a/images/wordpress/mu-plugins/mailcatcher.php
+++ b/images/wordpress/mu-plugins/mailcatcher.php
@@ -6,3 +6,7 @@ add_action('phpmailer_init', function ($phpmailer) {
     $phpmailer->SMTPAuth = false;
     $phpmailer->isSMTP();
 });
+
+add_filter('wp_mail_from', function ($mail) {
+    return 'wordpress@localhost.invalid';
+});


### PR DESCRIPTION
Problem: In WordPress 5.5, the PHPMailer version was upgraded from 5.2 to 6.1. PHPMailer changed its default address validator from "auto" to "php" as part of this bump. In response, WordPress replaced the call to the PHPMailer in-built address validator with a call to WordPress' `is_email()` function. The default from address for sites running in wpc (wordpress@localhost), does not pass the `is_email()` test (because the domain only has a single part), which resulted in no emails being sent.

Solution: In the `mailcatcher.php` mu-plugin, hook into the `wp_mail_from` filter to set a valid from address. We have to do this separately from the hook into the `phpmailer_init` action, as WordPress sets the from address (and thus triggers the error) before calling `phpmailer_init`.

Related WordPress core commit: https://github.com/WordPress/WordPress/commit/53c909a8256bbd481656ae864a4b7eb5a22c3692

Resolves: #54