### PR TITLE
Add the PHP SOAP extension to the WordPress image

### DIFF
--- a/images/wordpress/Dockerfile
+++ b/images/wordpress/Dockerfile
@@ -14,6 +14,7 @@ RUN docker-php-ext-install mysqli && \
     docker-php-ext-install sysvsem &&\
     docker-php-ext-install bcmath &&\
     docker-php-ext-install exif &&\
+    docker-php-ext-install soap &&\
     docker-php-ext-enable imagick && \
     a2enmod rewrite
 


### PR DESCRIPTION
We have plugins that use the SOAP extension to make queries to APIs
(e.g. https://github.com/dxw/hackney-jobs-sync). Adding the SOAP
extension to the docker image will allow us to run those plugins locally
without any further customisation.