### PR TITLE
Prevent default theme installation

### DIFF
--- a/images/wordpress/wp-config.php
+++ b/images/wordpress/wp-config.php
@@ -44,6 +44,7 @@ if (!defined('WP_DEBUG')) {
 define('WP_DEBUG_DISPLAY', true);
 define('WP_ALLOW_MULTISITE', true);
 define('FS_METHOD', 'direct');
+define('CORE_UPGRADE_SKIP_NEW_BUNDLED', true);
 
 define('AUTH_KEY',         'put your unique phrase here');
 define('SECURE_AUTH_KEY',  'put your unique phrase here');


### PR DESCRIPTION
WordPress' default behaviour to to install any new default themes when a
version upgrade happens. We never want those, so let's stop it
happening.

Note that contrary to the note in the WordPress source code, this
variable needs to be set to true to disable auto theme installation (as
the name would suggest).

See https://core.trac.wordpress.org/browser/tags/5.3/src/wp-admin/includes/update-core.php#L810
and https://core.trac.wordpress.org/ticket/49056