### PR TITLE
Add ClamAV

### DIFF
--- a/images/wordpress/Dockerfile
+++ b/images/wordpress/Dockerfile
@@ -1,6 +1,6 @@
 FROM php:7.4-apache
 
-RUN apt-get update && apt-get install -y --no-install-recommends libmagickwand-dev libjpeg-dev libpng-dev vim-tiny less mariadb-client libgmp-dev libsodium-dev zlib1g-dev libzip-dev && rm -r /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -y --no-install-recommends clamav libmagickwand-dev libjpeg-dev libpng-dev vim-tiny less mariadb-client libgmp-dev libsodium-dev zlib1g-dev libzip-dev && rm -r /var/lib/apt/lists/* && freshclam
 
 RUN pecl install imagick
 


### PR DESCRIPTION
This PR adds the ClamAV `clamscan` command to the WPC image, to assist with development of the dxw Virus Scanner plugin.

## How to test

1. Pull this branch and cd into the `images/wordpress` folder
2. Run `docker build -t local/my-wordpress-image .` to build a local copy of the modified image
3. Clone a basic GovPress repo (e.g. https://github.com/dxw/wordpress-template), and in that repo:
4. Edit the `docker-compose.yml` file to use your local WordPress image, by changing `image: thedxw/wpc-wordpress` to `image: local/my-wordpress-image`
5. Start the docker network with `docker-compose up -d` (don't use `script/server`, as this will try and fail to pull a remote image)
6. Use `script/console` to start a shell session in the WordPress container
7. In the container, run `clamscan xmlrpc.php` to scan the `xmlrpc.php` file. It should return the following output:
   ```
   /var/www/html/xmlrpc.php: OK

   ----------- SCAN SUMMARY -----------
   Known viruses: 2029770
   Engine version: 0.103.9
   Scanned directories: 0
   Scanned files: 1
   Infected files: 0
   Data scanned: 0.00 MB
   Data read: 0.00 MB (ratio 0.00:1)
   Time: 7.948 sec (0 m 7 s)
   Start Date: 2023:11:01 15:15:41
   End Date:   2023:11:01 15:15:49
   ```