### PR TITLE
Allow env vars to control wp-config.php settings

### DIFF
--- a/images/wordpress/wp-config.php
+++ b/images/wordpress/wp-config.php
@@ -12,53 +12,53 @@ if (file_exists('/usr/src/app/config/server-local.php')) {
 
 // For some reason this is not being set correctly by default
 if (!defined('DB_CHARSET')) {
-    define('DB_CHARSET', 'utf8mb4');
+    define('DB_CHARSET', $_ENV['DB_CHARSET'] ?? 'utf8mb4');
 }
 
 // Set URLs if they aren't set already
 $host = isset($_SERVER['SERVER_NAME']) ? $_SERVER['SERVER_NAME'] : 'localhost';
 if (!defined('WP_SITEURL')) {
-    define('WP_SITEURL', 'http://'.$host);
+    define('WP_SITEURL', $_ENV['WP_SITEURL'] ?? 'http://'.$host);
 }
 if (!defined('WP_HOME')) {
-    define('WP_HOME', 'http://'.$host);
+    define('WP_HOME', $_ENV['WP_HOME'] ?? 'http://'.$host);
 }
 
 // beanstalk
-define('BEANSTALKD_HOST', 'beanstalk');
+define('BEANSTALKD_HOST', $_ENV['BEANSTALKD_HOST'] ?? 'beanstalk');
 
 // mu-plugins
-define('WPMU_PLUGIN_DIR', '/usr/src/mu-plugins');
+define('WPMU_PLUGIN_DIR', $_ENV['WPMU_PLUGIN_DIR'] ?? '/usr/src/mu-plugins');
 
 // Database
-define('DB_HOST', 'mysql:3306');
-define('DB_NAME', 'wordpress');
-define('DB_USER', 'root');
-define('DB_PASSWORD', 'foobar');
+define('DB_HOST', $_ENV['DB_HOST'] ?? 'mysql:3306');
+define('DB_NAME', $_ENV['DB_NAME'] ?? 'wordpress');
+define('DB_USER', $_ENV['DB_USER'] ?? 'root');
+define('DB_PASSWORD', $_ENV['DB_PASSWORD'] ?? 'foobar');
 
 // wp-config stuff
 
 if (!defined('WP_DEBUG')) {
-    define('WP_DEBUG', false);
+    define('WP_DEBUG', $_ENV['WP_DEBUG'] ?? false);
 }
-define('WP_DEBUG_DISPLAY', true);
-define('WP_ALLOW_MULTISITE', true);
-define('FS_METHOD', 'direct');
-define('CORE_UPGRADE_SKIP_NEW_BUNDLED', true);
+define('WP_DEBUG_DISPLAY', $_ENV['WP_DEBUG_DISPLAY'] ?? true);
+define('WP_ALLOW_MULTISITE', $_ENV['WP_ALLOW_MULTISITE'] ?? true);
+define('FS_METHOD', $_ENV['FS_METHOD'] ?? 'direct');
+define('CORE_UPGRADE_SKIP_NEW_BUNDLED', $_ENV['CORE_UPGRADE_SKIP_NEW_BUNDLED'] ?? true);
 
-define('AUTH_KEY',         'put your unique phrase here');
-define('SECURE_AUTH_KEY',  'put your unique phrase here');
-define('LOGGED_IN_KEY',    'put your unique phrase here');
-define('NONCE_KEY',        'put your unique phrase here');
-define('AUTH_SALT',        'put your unique phrase here');
-define('SECURE_AUTH_SALT', 'put your unique phrase here');
-define('LOGGED_IN_SALT',   'put your unique phrase here');
-define('NONCE_SALT',       'put your unique phrase here');
+define('AUTH_KEY',         $_ENV['AUTH_KEY'] ?? 'put your unique phrase here');
+define('SECURE_AUTH_KEY',  $_ENV['SECURE_AUTH_KEY'] ?? 'put your unique phrase here');
+define('LOGGED_IN_KEY',    $_ENV['LOGGED_IN_KEY'] ?? 'put your unique phrase here');
+define('NONCE_KEY',        $_ENV['NONCE_KEY'] ?? 'put your unique phrase here');
+define('AUTH_SALT',        $_ENV['AUTH_SALT'] ?? 'put your unique phrase here');
+define('SECURE_AUTH_SALT', $_ENV['SECURE_AUTH_SALT'] ?? 'put your unique phrase here');
+define('LOGGED_IN_SALT',   $_ENV['LOGGED_IN_SALT'] ?? 'put your unique phrase here');
+define('NONCE_SALT',       $_ENV['NONCE_SALT'] ?? 'put your unique phrase here');
 
-define('WPLANG', '');
+define('WPLANG', $_ENV['WPLANG'] ?? '');
 if (!defined('ABSPATH')) {
-    define('ABSPATH', dirname(__FILE__) . '/');
+    define('ABSPATH', $_ENV['ABSPATH'] ?? dirname(__FILE__) . '/');
 }
-$table_prefix = 'wp_';
+$table_prefix = $_ENV['TABLE_PREFIX'] ?? 'wp_';
 
 require_once(ABSPATH . 'wp-settings.php');


### PR DESCRIPTION
This PR makes all the settings in the `wp-config.php` file controllable by env vars. The hardcoded settings have caused us issues in the past, because they mean that e.g. it's not possible to run a wpc-based WordPress instance that can be pointed at two different database instances (e.g. to switch between a development and a test db). This means we end up having to wrangle a single database to switch between test and development data, e.g. by backing up dev data before running a test suite, and then having to restore that backup once the tests are complete.

By making all the settings over-ridable by env vars, it's easy to point a WordPress container at different database instances, or even to run two different WordPress instances side-by-side on different ports, with each pointing at a different db.

I wouldn't expect us to to ever need to over-ride a lot of the settings in the file, but it was simple to extend the approach to every variable in `wp-config.php`, so that's what I've done.

## How to test

1. Pull this branch, and build a local copy of this image: 

   ```
   cd images/wordpress
   docker build -t local/test-wordpress-image .
   ```
2. Pick an example Whippet project (ideally one you already have a db set up for locally, but any of our docker-based WordPress projects will work), and in the `docker-compose.yml` file replace `image: thedxw/wpc-wordpress` with `image:local/test-wordpress-image`. When you run `docker-compose up`, the site should start up as normal.
3. Now add a second MySQL container to the `docker-compose.yml` file, as follows:
   ```
   mysql_test:
     image: mariadb:10
     ports:
       - "3308:3306"
     volumes:
       - mysql_test_data:/var/lib/mysql
     environment:
       MYSQL_DATABASE: wordpress
       MYSQL_ROOT_PASSWORD: foobar
   ```
4. Add the following to the end of the `wordpress` image in the `docker-compose.yml`:
   ```
   environment:
      - DB_HOST=${DB_HOST}
   ```
5. Add `  mysql_test_data:` to the list of volumes at the top of `docker-compose.yml`.
6. Stop your existing docker containers, and then start the network again with `DB_HOST=mysql_test docker compose up`. When you visit http://localhost, you should find you're at the start of a fresh WordPress install process. Complete the process and setup a basic site.
7. Now stop the containers and re-start them in their original state, using `DB_HOST=mysql docker compose up`. You should find you're now viewing your original dev site. You can now switch between them by stopping and re-starting the network with the appropriate `DB_HOST` variable, and the unique data for both should persist across docker stop/starts.