### PR TITLE
Add PHP MySQL extensions

### DIFF
--- a/images/wordpress/Dockerfile
+++ b/images/wordpress/Dockerfile
@@ -16,6 +16,8 @@ RUN docker-php-ext-install mysqli && \
     docker-php-ext-install exif &&\
     docker-php-ext-install soap &&\
     docker-php-ext-enable imagick && \
+    docker-php-ext-install pdo pdo_mysql &&\
+    docker-php-ext-enable mysqli && \
     a2enmod rewrite
 
 RUN curl --silent https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar > /usr/local/bin/wp-cli.phar

--- a/images/wordpress/Dockerfile
+++ b/images/wordpress/Dockerfile
@@ -4,8 +4,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends clamav libmagic
 
 RUN pecl install imagick
 
-RUN docker-php-ext-install mysqli && \
-    docker-php-ext-install gd && \
+RUN docker-php-ext-install gd && \
     docker-php-ext-install gmp && \
     docker-php-ext-install sodium && \
     docker-php-ext-install zip && \
@@ -17,6 +16,7 @@ RUN docker-php-ext-install mysqli && \
     docker-php-ext-install soap &&\
     docker-php-ext-enable imagick && \
     docker-php-ext-install pdo pdo_mysql &&\
+    docker-php-ext-install mysqli && \
     docker-php-ext-enable mysqli && \
     a2enmod rewrite
 


### PR DESCRIPTION
**Note: this PR is to merge into the php8.2 branch, not `main`**

The PHP8-compatible versions of WPBrowser & Codeception, that we use to run integration/acceptance tests on plugins like
dxw-Comment-Notifications and dxw-Digest, have changed the way they communicate with databases. They now require these additional extensions to be able to do so.

Adding them to our local image means we will be able to upgrade those tests to work on PHP8.