### PR TITLE
Feat: generate ssl-cert

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Example `docker-compose.yml` file (the last two lines should be added - the rest
     image: thedxw/wpc-wordpress
     ports:
       - "80:80"
+      - "443:443"
     links:
       - mysql
       - mailcatcher

--- a/images/wordpress/Dockerfile
+++ b/images/wordpress/Dockerfile
@@ -33,12 +33,14 @@ COPY mu-plugins /usr/src/mu-plugins/
 COPY wp-config.php /var/www/html/wp-config.php
 
 COPY openssl.cnf /etc/ssl/openssl.cnf
-RUN openssl req -x509 -out /etc/ssl/certs/apache-localhost.crt \
+RUN openssl req -x509 -days 3650 -out /etc/ssl/certs/apache-localhost.crt \
     -keyout /etc/ssl/private/apache-localhost.key \
     -newkey rsa:2048 -nodes -sha256 \
     -subj '/CN=localhost' \
     -extensions EXT \
     -config /etc/ssl/openssl.cnf 
+
+
 COPY apache-https.conf /etc/apache2/sites-available/
 RUN a2enmod ssl
 RUN a2ensite apache-https

--- a/images/wordpress/Dockerfile
+++ b/images/wordpress/Dockerfile
@@ -32,5 +32,16 @@ COPY wordpress.conf /etc/apache2/sites-enabled/
 COPY mu-plugins /usr/src/mu-plugins/
 COPY wp-config.php /var/www/html/wp-config.php
 
+COPY openssl.cnf /etc/ssl/openssl.cnf
+RUN openssl req -x509 -out /etc/ssl/certs/apache-localhost.crt \
+    -keyout /etc/ssl/private/apache-localhost.key \
+    -newkey rsa:2048 -nodes -sha256 \
+    -subj '/CN=localhost' \
+    -extensions EXT \
+    -config /etc/ssl/openssl.cnf 
+COPY apache-https.conf /etc/apache2/sites-available/
+RUN a2enmod ssl
+RUN a2ensite apache-https
+
 ENTRYPOINT ["wp-start"]
 CMD ["apache2-foreground"]

--- a/images/wordpress/apache-https.conf
+++ b/images/wordpress/apache-https.conf
@@ -1,0 +1,8 @@
+<VirtualHost *:443>
+	DocumentRoot "/var/www/html"
+	ServerName localhost
+
+	SSLEngine on
+    	SSLCertificateFile "/etc/ssl/certs/apache-localhost.crt"
+    	SSLCertificateKeyFile "/etc/ssl/private/apache-localhost.key"
+</VirtualHost>

--- a/images/wordpress/openssl.cnf
+++ b/images/wordpress/openssl.cnf
@@ -1,8 +1,9 @@
- [dn]
+[dn]
 CN=localhost
 [req]
-distinguished_name = dn
+distinguished_name = dn 
 [EXT]
 subjectAltName=DNS:localhost
 keyUsage=digitalSignature
 extendedKeyUsage=serverAuth
+

--- a/images/wordpress/openssl.cnf
+++ b/images/wordpress/openssl.cnf
@@ -1,0 +1,8 @@
+ [dn]
+CN=localhost
+[req]
+distinguished_name = dn
+[EXT]
+subjectAltName=DNS:localhost
+keyUsage=digitalSignature
+extendedKeyUsage=serverAuth


### PR DESCRIPTION
This PR is in relation to the issue: Enable HTTPS #57 automated SSL certificate generation and modifications to the Docker image to enable HTTPS support in the WordPress container in local environment . 

The ssl key is generated by a command found in the following article: https://letsencrypt.org/docs/certificates-for-localhost/

### How to Test
- run `docker build -t wpc:https images/wordpress/`
- run `docker run -p 127.0.0.1:80:80 wpc:https`
- run `docker run -p 127.0.0.1:443:433 wpc:https`

- These steps are for building the image and verify that the container run port 80 and port 443 with name `wpc` and tag `https`. Then you can exit and run the `wpc:https images/wordpress/` run on the `saluki-test-site`. 
- run `script/server`
- Open the browser and check if `https://localhost` opens and check if the ssl-certificate is attached.



