### PR TITLE
Ssl-certificate extend date

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Example `docker-compose.yml` file (the last two lines should be added - the rest
     image: thedxw/wpc-wordpress
     ports:
       - "80:80"
+      - "443:443"
     links:
       - mysql
       - mailcatcher

--- a/images/wordpress/Dockerfile
+++ b/images/wordpress/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.4-apache
+FROM php:8.2-apache
 
 RUN apt-get update && apt-get install -y --no-install-recommends clamav libmagickwand-dev libjpeg-dev libpng-dev vim-tiny less mariadb-client libgmp-dev libsodium-dev zlib1g-dev libzip-dev && rm -r /var/lib/apt/lists/* && freshclam
 

--- a/images/wordpress/Dockerfile
+++ b/images/wordpress/Dockerfile
@@ -16,6 +16,8 @@ RUN docker-php-ext-install mysqli && \
     docker-php-ext-install exif &&\
     docker-php-ext-install soap &&\
     docker-php-ext-enable imagick && \
+    docker-php-ext-install pdo pdo_mysql &&\
+    docker-php-ext-enable mysqli && \
     a2enmod rewrite
 
 RUN curl --silent https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar > /usr/local/bin/wp-cli.phar

--- a/images/wordpress/Dockerfile
+++ b/images/wordpress/Dockerfile
@@ -35,12 +35,14 @@ COPY mu-plugins /usr/src/mu-plugins/
 COPY wp-config.php /var/www/html/wp-config.php
 
 COPY openssl.cnf /etc/ssl/openssl.cnf
-RUN openssl req -x509 -out /etc/ssl/certs/apache-localhost.crt \
+RUN openssl req -x509 -days 3650 -out /etc/ssl/certs/apache-localhost.crt \
     -keyout /etc/ssl/private/apache-localhost.key \
     -newkey rsa:2048 -nodes -sha256 \
     -subj '/CN=localhost' \
     -extensions EXT \
     -config /etc/ssl/openssl.cnf 
+
+
 COPY apache-https.conf /etc/apache2/sites-available/
 RUN a2enmod ssl
 RUN a2ensite apache-https

--- a/images/wordpress/Dockerfile
+++ b/images/wordpress/Dockerfile
@@ -34,5 +34,16 @@ COPY wordpress.conf /etc/apache2/sites-enabled/
 COPY mu-plugins /usr/src/mu-plugins/
 COPY wp-config.php /var/www/html/wp-config.php
 
+COPY openssl.cnf /etc/ssl/openssl.cnf
+RUN openssl req -x509 -out /etc/ssl/certs/apache-localhost.crt \
+    -keyout /etc/ssl/private/apache-localhost.key \
+    -newkey rsa:2048 -nodes -sha256 \
+    -subj '/CN=localhost' \
+    -extensions EXT \
+    -config /etc/ssl/openssl.cnf 
+COPY apache-https.conf /etc/apache2/sites-available/
+RUN a2enmod ssl
+RUN a2ensite apache-https
+
 ENTRYPOINT ["wp-start"]
 CMD ["apache2-foreground"]

--- a/images/wordpress/Dockerfile
+++ b/images/wordpress/Dockerfile
@@ -4,8 +4,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends clamav libmagic
 
 RUN pecl install imagick
 
-RUN docker-php-ext-install mysqli && \
-    docker-php-ext-install gd && \
+RUN docker-php-ext-install gd && \
     docker-php-ext-install gmp && \
     docker-php-ext-install sodium && \
     docker-php-ext-install zip && \
@@ -17,6 +16,7 @@ RUN docker-php-ext-install mysqli && \
     docker-php-ext-install soap &&\
     docker-php-ext-enable imagick && \
     docker-php-ext-install pdo pdo_mysql &&\
+    docker-php-ext-install mysqli && \
     docker-php-ext-enable mysqli && \
     a2enmod rewrite
 

--- a/images/wordpress/apache-https.conf
+++ b/images/wordpress/apache-https.conf
@@ -1,0 +1,8 @@
+<VirtualHost *:443>
+	DocumentRoot "/var/www/html"
+	ServerName localhost
+
+	SSLEngine on
+    	SSLCertificateFile "/etc/ssl/certs/apache-localhost.crt"
+    	SSLCertificateKeyFile "/etc/ssl/private/apache-localhost.key"
+</VirtualHost>

--- a/images/wordpress/openssl.cnf
+++ b/images/wordpress/openssl.cnf
@@ -1,8 +1,9 @@
- [dn]
+[dn]
 CN=localhost
 [req]
-distinguished_name = dn
+distinguished_name = dn 
 [EXT]
 subjectAltName=DNS:localhost
 keyUsage=digitalSignature
 extendedKeyUsage=serverAuth
+

--- a/images/wordpress/openssl.cnf
+++ b/images/wordpress/openssl.cnf
@@ -1,0 +1,8 @@
+ [dn]
+CN=localhost
+[req]
+distinguished_name = dn
+[EXT]
+subjectAltName=DNS:localhost
+keyUsage=digitalSignature
+extendedKeyUsage=serverAuth


### PR DESCRIPTION
This PR is a follow up to the issue #57 and #65. The purpose here is to extend the ssl-certification expire date form 1st of March 20225 to 1 February 2035 

Please for How to Test, refer to PR https://github.com/dxw/wpc/pull/65 